### PR TITLE
Added alter to change citeproc read paths

### DIFF
--- a/uwsdora.module
+++ b/uwsdora.module
@@ -66,7 +66,7 @@ function uwsdora_islandora_required_objects(IslandoraTuque $connection) {
   $datastream->label = 'Thumbnail';
   $datastream->mimetype = 'image/png';
   $datastream->setContentFromFile("$islandora_path/images/folder.png", FALSE);
-  $thesis_collection->ingestDatastream($datastream);
+  $thesis_collection->ingestDatastream($datastream)
   // Collection Policy Datastream.
   $datastream = $thesis_collection->constructDatastream('COLLECTION_POLICY', 'X');
   $datastream->label = 'Collection policy';
@@ -105,4 +105,52 @@ function uwsdora_views_api() {
     'api' => 3,
     'path' => drupal_get_path('module', 'uwsdora') . '/views',
   );
+}
+
+/**
+ * Implements hook_convert_mods_to_citeproc_jsons_alter().
+ */
+function uwsdora_convert_mods_to_citeproc_jsons_alter($output, $mods, $pages) {
+  module_load_include('inc', 'citeproc', 'includes/converter');
+ 
+  $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
+  $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
+   
+  $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']");
+  
+  if (empty($pages)) {
+    $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='page']");
+  }
+
+  $pages = (!empty($pages) ? $pages[0] : NULL);
+  if ($pages) {
+    add_mods_namespace($pages);
+
+    $total = $pages->xpath('mods:total');
+    $total = (!empty($total) ? (string) $total[0] : NULL);
+
+    $list = $pages->xpath('mods:list');
+    $list = (!empty($list) ? (string) $list[0] : NULL);
+
+    $start = $pages->xpath('mods:start');
+    $start = (!empty($start) ? (string) $start[0] : NULL);
+
+    $end = $pages->xpath('mods:end');
+    $end = (!empty($end) ? (string) $end[0] : NULL);
+
+    if ($total) {
+      $output = $total;
+    }
+    elseif ($list) {
+      $output = $list;
+    }
+    elseif ($start) {
+      $output = $start;
+      if ($end) {
+        $output .= "-" . $end;
+      }
+    }
+  }
+
+  return $output;
 }

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -109,49 +109,51 @@ function uwsdora_views_api() {
 
 /**
  * Implements hook_convert_mods_to_citeproc_jsons_alter().
+ *
+ * @see citeproc/includes/converter.inc::convert_mods_to_citeproc_json_page()
  */
 function uwsdora_convert_mods_to_citeproc_jsons_alter(&$output, $mods) {
-  module_load_include('inc', 'citeproc', 'includes/converter');
+  $data = function($mods) {
+    $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']");
 
-  $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']");
-
-  if (empty($pages)) {
-    $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='page']");
-  }
-
-  $pages = (!empty($pages) ? $pages[0] : NULL);
-  if ($pages) {
-    add_mods_namespace($pages);
-
-    $total = $pages->xpath('mods:total');
-    $total = (!empty($total) ? (string) $total[0] : NULL);
-
-    $list = $pages->xpath('mods:list');
-    $list = (!empty($list) ? (string) $list[0] : NULL);
-
-    $start = $pages->xpath('mods:start');
-    $start = (!empty($start) ? (string) $start[0] : NULL);
-
-    $end = $pages->xpath('mods:end');
-    $end = (!empty($end) ? (string) $end[0] : NULL);
-
-    if ($total) {
-      $data = $total;
+    if (empty($pages)) {
+      $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='page']");
     }
-    elseif ($list) {
-      $data = $list;
-    }
-    elseif ($start) {
-      $data = $start;
 
-      if ($end) {
-        $data .= "-" . $end;
+    $pages = (!empty($pages) ? $pages[0] : NULL);
+    if ($pages) {
+      add_mods_namespace($pages);
+
+      $total = $pages->xpath('mods:total');
+      $total = (!empty($total) ? (string) $total[0] : NULL);
+
+      $list = $pages->xpath('mods:list');
+      $list = (!empty($list) ? (string) $list[0] : NULL);
+
+      $start = $pages->xpath('mods:start');
+      $start = (!empty($start) ? (string) $start[0] : NULL);
+
+      $end = $pages->xpath('mods:end');
+      $end = (!empty($end) ? (string) $end[0] : NULL);
+
+      if ($total) {
+        $output = $total;
       }
-    }
-  }
+      elseif ($list) {
+        $output = $list;
+      }
+      elseif ($start) {
+        $output = $start;
 
-  // Alter readpaths and use newly processed page information.
-  $output['page'] = $data;
+        if ($end) {
+          $output .= "-" . $end;
+        }
+      }
+      return $output;
+    }
+  };
+
+  $output['page'] = $data($mods);
   $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
   $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
 }

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -110,12 +110,8 @@ function uwsdora_views_api() {
 /**
  * Implements hook_convert_mods_to_citeproc_jsons_alter().
  */
-function uwsdora_convert_mods_to_citeproc_jsons_alter($output, $mods, $pages) {
-  // Custom read paths for citeproc
+function uwsdora_convert_mods_to_citeproc_jsons_alter(&$output, $mods) {
   module_load_include('inc', 'citeproc', 'includes/converter');
-
-  $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
-  $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
 
   $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']");
 
@@ -140,18 +136,22 @@ function uwsdora_convert_mods_to_citeproc_jsons_alter($output, $mods, $pages) {
     $end = (!empty($end) ? (string) $end[0] : NULL);
 
     if ($total) {
-      $output = $total;
+      $data = $total;
     }
     elseif ($list) {
-      $output = $list;
+      $data = $list;
     }
     elseif ($start) {
-      $output = $start;
+      $data = $start;
+
       if ($end) {
-        $output .= "-" . $end;
+        $data .= "-" . $end;
       }
     }
   }
 
-  return $output;
+  // Alter readpaths and use newly processed page information.
+  $output['page'] = $data;
+  $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
+  $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
 }

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -66,7 +66,7 @@ function uwsdora_islandora_required_objects(IslandoraTuque $connection) {
   $datastream->label = 'Thumbnail';
   $datastream->mimetype = 'image/png';
   $datastream->setContentFromFile("$islandora_path/images/folder.png", FALSE);
-  $thesis_collection->ingestDatastream($datastream)
+  $thesis_collection->ingestDatastream($datastream);
   // Collection Policy Datastream.
   $datastream = $thesis_collection->constructDatastream('COLLECTION_POLICY', 'X');
   $datastream->label = 'Collection policy';
@@ -111,13 +111,14 @@ function uwsdora_views_api() {
  * Implements hook_convert_mods_to_citeproc_jsons_alter().
  */
 function uwsdora_convert_mods_to_citeproc_jsons_alter($output, $mods, $pages) {
+  // Custom read paths for citeproc
   module_load_include('inc', 'citeproc', 'includes/converter');
- 
+
   $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
   $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
-   
+
   $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']");
-  
+
   if (empty($pages)) {
     $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='page']");
   }

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -109,11 +109,10 @@ function uwsdora_views_api() {
 
 /**
  * Implements hook_convert_mods_to_citeproc_jsons_alter().
- *
- * @see citeproc/includes/converter.inc::convert_mods_to_citeproc_json_page()
  */
 function uwsdora_convert_mods_to_citeproc_jsons_alter(&$output, $mods) {
-  $data = function($mods) {
+  // @see citeproc/includes/converter.inc::convert_mods_to_citeproc_json_page()
+  $extract_page_info = function($mods) {
     $pages = $mods->xpath("//mods:mods[1]/mods:relatedItem[@type='host']/mods:part/mods:extent[@unit='pages']");
 
     if (empty($pages)) {
@@ -153,7 +152,7 @@ function uwsdora_convert_mods_to_citeproc_jsons_alter(&$output, $mods) {
     }
   };
 
-  $output['page'] = $data($mods);
+  $output['page'] = $extract_page_info($mods);
   $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
   $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
 }


### PR DESCRIPTION
Client's metadata was not compatible with citeproc's readpaths in the converter.inc.

The client's desired readpaths (based on changed code found on prod):
```
'volume' => (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number')

'issue' => (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number')
```

And had to alter the $pages in convert_mods_to_citeproc_json_page function, found in citeproc/includes/converter.inc L 301.