### PR TITLE
Display MODS title and MODS alternative title if present in MODS record

### DIFF
--- a/uwsdora.module
+++ b/uwsdora.module
@@ -156,3 +156,29 @@ function uwsdora_convert_mods_to_citeproc_jsons_alter(&$output, $mods) {
   $output['volume'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="volume"]/mods:number');
   $output['issue'] = (int) convert_mods_to_citeproc_json_query($mods, '//mods:mods[1]/mods:relatedItem[@type="host"]/mods:part/mods:detail[@type="issue"]/mods:number');
 }
+
+/**
+ * Implements hook_islandora_object_view().
+ */
+function uwsdora_islandora_view_object_alter(&$object, &$rendered) {
+
+  if (isset($object['MODS'])) {
+    $document = new DOMDocument();
+    $document->loadXML($object['MODS']->content);
+
+    if ($document) {
+      $xpath = new DOMXpath($document);
+      $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
+
+      $results = $xpath->query('mods:titleInfo[not (contains(@type, "alternative"))]/mods:title');
+      $node = $results->item(0);
+      $title = (isset($node)) ? $node->textContent : "";
+
+      $results = $xpath->query('mods:titleInfo[contains(@type, "alternative")]/mods:title');
+      $node = $results->item(0);
+      $title_alternative = (isset($node)) ? $node->textContent : "";
+
+      drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/><span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
+    }
+  }
+}

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -178,7 +178,9 @@ function uwsdora_islandora_view_object_alter(&$object, &$rendered) {
       $node = $results->item(0);
       $title_alternative = (isset($node)) ? $node->textContent : "";
 
-      drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/><span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
+      if (!empty($title) || !empty($title_alternative)) {
+        drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/><span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
+      }
     }
   }
 }

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -158,7 +158,7 @@ function uwsdora_convert_mods_to_citeproc_jsons_alter(&$output, $mods) {
 }
 
 /**
- * Implements hook_islandora_object_view().
+ * Implements hook_islandora_view_object_alter().
  */
 function uwsdora_islandora_view_object_alter(&$object, &$rendered) {
 
@@ -170,16 +170,11 @@ function uwsdora_islandora_view_object_alter(&$object, &$rendered) {
       $xpath = new DOMXpath($document);
       $xpath->registerNamespace('mods', 'http://www.loc.gov/mods/v3');
 
-      $results = $xpath->query('mods:titleInfo[not (contains(@type, "alternative"))]/mods:title');
-      $node = $results->item(0);
-      $title = (isset($node)) ? $node->textContent : "";
+      $title = $xpath->evaluate('normalize-space(/mods:mods/mods:titleInfo[not(@type)]/mods:title)');
+      $title_alternative = $xpath->evaluate('normalize-space(/mods:mods/mods:titleInfo[@type="alternative"]/mods:title)');
 
-      $results = $xpath->query('mods:titleInfo[contains(@type, "alternative")]/mods:title');
-      $node = $results->item(0);
-      $title_alternative = (isset($node)) ? $node->textContent : "";
-
-      if (!empty($title) || !empty($title_alternative)) {
-        drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/> <span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
+      if (!empty($title) && !empty($title_alternative)) {
+        drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/><span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
       }
     }
   }

--- a/uwsdora.module
+++ b/uwsdora.module
@@ -179,7 +179,7 @@ function uwsdora_islandora_view_object_alter(&$object, &$rendered) {
       $title_alternative = (isset($node)) ? $node->textContent : "";
 
       if (!empty($title) || !empty($title_alternative)) {
-        drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/><span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
+        drupal_set_title(t("<span class='uwsdora-mods-title'>@title1</span><br/> <span class='uwsdora-mods-title-alternative'>@title2</span>", array('@title1' => $title, '@title2' => $title_alternative)), PASS_THROUGH);
       }
     }
   }


### PR DESCRIPTION
UWS has requested that we create a functionality that changes the object view page's title to mods:titleInfo/mods:title and mods:titleInfo[@ type="alternative"]/mods:title. The title only changes if either values are found in the MODS record.